### PR TITLE
feat: support commit hash builds for installation

### DIFF
--- a/cmd/current.go
+++ b/cmd/current.go
@@ -42,8 +42,8 @@ var currentCmd = &cobra.Command{
 				fmt.Printf("%s %s\n", utils.InfoIcon(), utils.WhiteText(fmt.Sprintf("nightly (%s)", current)))
 			} else {
 				shortCommit := nightly.CommitHash
-				if len(shortCommit) > 10 {
-					shortCommit = shortCommit[:10]
+				if len(shortCommit) > 7 {
+					shortCommit = shortCommit[:7]
 				}
 				publishedStr := nightly.PublishedAt
 				if t, err := time.Parse(time.RFC3339, nightly.PublishedAt); err == nil {
@@ -56,8 +56,17 @@ var currentCmd = &cobra.Command{
 				logrus.Debugf("Latest nightly commit: %s, Published: %s", shortCommit, publishedStr)
 			}
 		default:
-			logrus.Debugf("Displaying custom version: %s", current)
-			fmt.Printf("%s %s\n", utils.InfoIcon(), utils.WhiteText(current))
+			isCommitHash := releases.IsCommitHash(current)
+			logrus.Debugf("isCommitHash: %t", isCommitHash)
+
+			if isCommitHash {
+				logrus.Debugf("Displaying custom commit hash: %s", current)
+				fmt.Printf("%s %s %s\n", utils.InfoIcon(), utils.WhiteText("Commit Hash:"), utils.CyanText(current))
+			} else {
+				logrus.Debugf("Displaying custom version: %s", current)
+				fmt.Printf("%s %s\n", utils.InfoIcon(), utils.WhiteText(current))
+			}
+
 		}
 	},
 }

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -5,15 +5,16 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/y3owk1n/nvs/pkg/builder"
 	"github.com/y3owk1n/nvs/pkg/installer"
 	"github.com/y3owk1n/nvs/pkg/releases"
 	"github.com/y3owk1n/nvs/pkg/utils"
 )
 
 var installCmd = &cobra.Command{
-	Use:     "install <version|stable|nightly>",
+	Use:     "install <version|stable|nightly|master|commit-hash>",
 	Aliases: []string{"i"},
-	Short:   "Install a Neovim version",
+	Short:   "Install a Neovim version or commit",
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		logrus.Debug("Starting installation command")
@@ -22,8 +23,20 @@ var installCmd = &cobra.Command{
 		logrus.Debugf("Normalized version: %s", alias)
 		fmt.Printf("%s %s\n", utils.InfoIcon(), utils.WhiteText(fmt.Sprintf("Resolving version %s...", utils.CyanText(alias))))
 
-		if err := installer.InstallVersion(alias, versionsDir, cacheFilePath); err != nil {
-			logrus.Fatalf("%v", err)
+		isCommitHash := releases.IsCommitHash(alias)
+		logrus.Debugf("isCommitHash: %t", isCommitHash)
+
+		if isCommitHash {
+			logrus.Debugf("Building Neovim from commit %s", alias)
+			fmt.Printf("%s %s\n", utils.InfoIcon(), utils.WhiteText("Building Neovim from commit "+utils.CyanText(alias)))
+			if err := builder.BuildFromCommit(alias, versionsDir); err != nil {
+				logrus.Fatalf("%v", err)
+			}
+		} else {
+			logrus.Debugf("Start installing %s", alias)
+			if err := installer.InstallVersion(alias, versionsDir, cacheFilePath); err != nil {
+				logrus.Fatalf("%v", err)
+			}
 		}
 	},
 }

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -1,0 +1,121 @@
+package builder
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/briandowns/spinner"
+	"github.com/sirupsen/logrus"
+	"github.com/y3owk1n/nvs/pkg/utils"
+)
+
+const repoURL = "https://github.com/neovim/neovim.git"
+
+var (
+	execCommandFunc = exec.Command
+	copyFileFunc    = utils.CopyFile
+)
+
+func BuildFromCommit(commit, versionsDir string) error {
+	localPath := filepath.Join(os.TempDir(), "neovim-src")
+
+	s := spinner.New(spinner.CharSets[14], 100*time.Millisecond)
+	s.Start()
+	defer s.Stop()
+
+	if _, err := os.Stat(localPath); os.IsNotExist(err) {
+		s.Suffix = " Cloning repository..."
+		logrus.Debug("Cloning repository from ", repoURL)
+		cloneCmd := execCommandFunc("git", "clone", repoURL, localPath)
+		cloneCmd.Stdout = os.Stdout
+		cloneCmd.Stderr = os.Stderr
+		if err := cloneCmd.Run(); err != nil {
+			return fmt.Errorf("failed to clone repository: %v", err)
+		}
+	}
+
+	if commit == "master" {
+		s.Suffix = " Checking out master branch..."
+		logrus.Debug("Checking out master branch")
+		checkoutCmd := execCommandFunc("git", "checkout", "master")
+		checkoutCmd.Dir = localPath
+		checkoutCmd.Stdout = os.Stdout
+		checkoutCmd.Stderr = os.Stderr
+		if err := checkoutCmd.Run(); err != nil {
+			return fmt.Errorf("failed to checkout master branch: %v", err)
+		}
+
+		s.Suffix = " Pulling latest changes..."
+		logrus.Debug("Pulling latest changes on master branch")
+		pullCmd := execCommandFunc("git", "pull", "origin", "master")
+		pullCmd.Dir = localPath
+		pullCmd.Stdout = os.Stdout
+		pullCmd.Stderr = os.Stderr
+		if err := pullCmd.Run(); err != nil {
+			return fmt.Errorf("failed to pull latest changes: %v", err)
+		}
+	} else {
+		s.Suffix = " Checking out commit " + commit + "..."
+		logrus.Debug("Checking out commit ", commit)
+		checkoutCmd := execCommandFunc("git", "checkout", commit)
+		checkoutCmd.Dir = localPath
+		checkoutCmd.Stdout = os.Stdout
+		checkoutCmd.Stderr = os.Stderr
+		if err := checkoutCmd.Run(); err != nil {
+			return fmt.Errorf("failed to checkout commit %s: %v", commit, err)
+		}
+	}
+
+	cmd := execCommandFunc("git", "rev-parse", "HEAD")
+	cmd.Dir = localPath
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to get current commit hash: %v", err)
+	}
+	commitHash := strings.TrimSpace(out.String())[:7]
+	logrus.Debug("Current commit hash: ", commitHash)
+
+	s.Suffix = " Building Neovim..."
+	logrus.Debug("Building Neovim...")
+	buildCmd := execCommandFunc("make", "CMAKE_BUILD_TYPE=Release")
+	buildCmd.Dir = localPath
+	buildCmd.Stdout = os.Stdout
+	buildCmd.Stderr = os.Stderr
+	if err := buildCmd.Run(); err != nil {
+		return fmt.Errorf("build failed: %v", err)
+	}
+
+	binaryPath := filepath.Join(localPath, "build", "bin", "nvim")
+	if _, err := os.Stat(binaryPath); os.IsNotExist(err) {
+		binaryPath = filepath.Join(localPath, "bin", "nvim")
+		if _, err := os.Stat(binaryPath); os.IsNotExist(err) {
+			return fmt.Errorf("built binary not found")
+		}
+	}
+
+	targetDir := filepath.Join(versionsDir, commitHash)
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		return fmt.Errorf("failed to create installation directory: %v", err)
+	}
+	targetPath := filepath.Join(targetDir, "nvim")
+
+	if err := copyFileFunc(binaryPath, targetPath); err != nil {
+		return fmt.Errorf("failed to copy built binary: %v", err)
+	}
+
+	versionFile := filepath.Join(targetDir, "version.txt")
+	if err := os.WriteFile(versionFile, []byte(commitHash), 0644); err != nil {
+		return fmt.Errorf("failed to write version file: %v", err)
+	}
+
+	s.Suffix = " Build complete!"
+	logrus.Debug("Build and installation successful")
+	fmt.Printf("\n%s %s\n", utils.SuccessIcon(), utils.CyanText("Build and installation successful!"))
+	return nil
+}

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -1,0 +1,189 @@
+package builder
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fakeExecCommand is used to override execCommand in tests.
+func fakeExecCommand(command string, args ...string) *exec.Cmd {
+	// We use the standard helper process trick.
+	// The arguments passed to the helper process are:
+	//   -test.run=TestHelperProcess
+	//   "--", the command, then its args.
+	cs := []string{"-test.run=TestHelperProcess", "--", command}
+	cs = append(cs, args...)
+	cmd := exec.Command(os.Args[0], cs...)
+	// Set an env var so the helper process knows it’s supposed to run.
+	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
+	return cmd
+}
+
+// TestHelperProcess is not a real test. It is invoked as a subprocess
+// by fakeExecCommand.
+func TestHelperProcess(t *testing.T) {
+	// Only run if the special env var is present.
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	// Parse the command and its arguments.
+	args := os.Args
+	// Our argument list should contain "--" followed by the command.
+	idx := 0
+	for i, arg := range args {
+		if arg == "--" {
+			idx = i + 1
+			break
+		}
+	}
+	if idx >= len(args) {
+		fmt.Fprint(os.Stderr, "no command provided")
+		os.Exit(1)
+	}
+	cmd := args[idx]
+	// For convenience, capture any subcommand.
+	var subcmd string
+	if len(args) > idx+1 {
+		subcmd = args[idx+1]
+	}
+
+	switch cmd {
+	case "git":
+		switch subcmd {
+		case "clone":
+			// Simulate cloning by creating the target directory.
+			// The last argument is assumed to be the destination.
+			dest := args[len(args)-1]
+			if err := os.MkdirAll(dest, 0755); err != nil {
+				fmt.Fprintf(os.Stderr, "failed to create dir: %v", err)
+				os.Exit(1)
+			}
+			os.Exit(0)
+		case "checkout":
+			// Simulate a successful checkout.
+			os.Exit(0)
+		case "pull":
+			// Simulate a successful pull.
+			os.Exit(0)
+		case "rev-parse":
+			// Simulate printing a commit hash.
+			// (This dummy hash must be at least 7 characters; we use "abcdef1\n")
+			fmt.Fprint(os.Stdout, "abcdef1\n")
+			os.Exit(0)
+		default:
+			os.Exit(0)
+		}
+	case "make":
+		// Simulate a successful build.
+		os.Exit(0)
+	default:
+		os.Exit(0)
+	}
+}
+
+// TestBuildFromCommit_Master tests the BuildFromCommit function when the commit is "master".
+func TestBuildFromCommit_Master(t *testing.T) {
+	// Override execCommand and utils.CopyFile for testing.
+	oldExecCommand := execCommandFunc
+	execCommandFunc = fakeExecCommand
+	defer func() { execCommandFunc = oldExecCommand }()
+
+	oldCopyFile := copyFileFunc
+	copyFileFunc = func(src, dst string) error {
+		// For testing, simply write a dummy binary file to dst.
+		return os.WriteFile(dst, []byte("dummy binary"), 0755)
+	}
+	defer func() { copyFileFunc = oldCopyFile }()
+
+	// Ensure that the local clone directory does not exist so that the clone branch is executed.
+	localPath := filepath.Join(os.TempDir(), "neovim-src")
+	os.RemoveAll(localPath)
+
+	// Create a temporary versions directory.
+	versionsDir, err := os.MkdirTemp("", "versions")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(versionsDir)
+
+	// To simulate a successful build, we need to ensure that the built binary exists.
+	// BuildFromCommit checks for the binary in two locations.
+	// Here we simulate the second location: localPath/bin/nvim.
+	binaryPath := filepath.Join(localPath, "bin", "nvim")
+	if err := os.MkdirAll(filepath.Dir(binaryPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(binaryPath, []byte("dummy binary"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Call BuildFromCommit with commit "master".
+	if err := BuildFromCommit("master", versionsDir); err != nil {
+		t.Fatalf("BuildFromCommit failed: %v", err)
+	}
+
+	// The BuildFromCommit function extracts the commit hash from "git rev-parse" output,
+	// takes its first 7 characters ("abcdef1"), and uses that as the target directory name.
+	targetDir := filepath.Join(versionsDir, "abcdef1")
+	versionFile := filepath.Join(targetDir, "version.txt")
+	data, err := os.ReadFile(versionFile)
+	if err != nil {
+		t.Fatalf("failed to read version file: %v", err)
+	}
+	if strings.TrimSpace(string(data)) != "abcdef1" {
+		t.Errorf("version file content = %q; want %q", string(data), "abcdef1")
+	}
+}
+
+// TestBuildFromCommit_Commit tests BuildFromCommit for a non-master commit.
+func TestBuildFromCommit_Commit(t *testing.T) {
+	oldExecCommand := execCommandFunc
+	execCommandFunc = fakeExecCommand
+	defer func() { execCommandFunc = oldExecCommand }()
+
+	oldCopyFile := copyFileFunc
+	copyFileFunc = func(src, dst string) error {
+		return os.WriteFile(dst, []byte("dummy binary"), 0755)
+	}
+	defer func() { copyFileFunc = oldCopyFile }()
+
+	// Remove the local clone directory so that the clone branch runs.
+	localPath := filepath.Join(os.TempDir(), "neovim-src")
+	os.RemoveAll(localPath)
+
+	versionsDir, err := os.MkdirTemp("", "versions")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(versionsDir)
+
+	// Create a dummy built binary file for the non-master branch.
+	binaryPath := filepath.Join(localPath, "bin", "nvim")
+	if err := os.MkdirAll(filepath.Dir(binaryPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(binaryPath, []byte("dummy binary"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Call BuildFromCommit with a non-master commit (e.g. "abc1234").
+	if err := BuildFromCommit("abc1234", versionsDir); err != nil {
+		t.Fatalf("BuildFromCommit failed: %v", err)
+	}
+
+	// The commit hash is always derived from the dummy output ("abcdef1").
+	targetDir := filepath.Join(versionsDir, "abcdef1")
+	versionFile := filepath.Join(targetDir, "version.txt")
+	data, err := os.ReadFile(versionFile)
+	if err != nil {
+		t.Fatalf("failed to read version file: %v", err)
+	}
+	if strings.TrimSpace(string(data)) != "abcdef1" {
+		t.Errorf("version file content = %q; want %q", string(data), "abcdef1")
+	}
+}

--- a/pkg/releases/releases.go
+++ b/pkg/releases/releases.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/Masterminds/semver"
 	"github.com/sirupsen/logrus"
@@ -102,8 +103,24 @@ func GetReleases() ([]Release, error) {
 	return FilterReleases(releases, "0.5.0")
 }
 
+func IsCommitHash(s string) bool {
+	if s == "master" {
+		return true
+	}
+
+	if len(s) != 7 && len(s) != 40 {
+		return false
+	}
+	for _, r := range s {
+		if !unicode.IsDigit(r) && (r < 'a' || r > 'f') && (r < 'A' || r > 'F') {
+			return false
+		}
+	}
+	return true
+}
+
 func NormalizeVersion(version string) string {
-	if version == "stable" || version == "nightly" {
+	if version == "stable" || version == "nightly" || IsCommitHash(version) {
 		return version
 	}
 	if !strings.HasPrefix(version, "v") {
@@ -209,7 +226,7 @@ func GetReleaseIdentifier(release Release, alias string) string {
 		if strings.HasPrefix(release.TagName, "nightly-") {
 			return strings.TrimPrefix(release.TagName, "nightly-")
 		}
-		return release.CommitHash[:10]
+		return release.CommitHash[:7]
 	}
 	return release.TagName
 }

--- a/pkg/releases/releases_test.go
+++ b/pkg/releases/releases_test.go
@@ -251,6 +251,48 @@ func TestGetReleases_Non200(t *testing.T) {
 	}
 }
 
+func TestIsCommitHash(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+		name     string
+	}{
+		// Special case: "master" should always return true.
+		{"master", true, "master keyword"},
+
+		// Invalid lengths (not 7 or 40)
+		{"", false, "empty string"},
+		{"abc", false, "too short"},
+		{"12345678", false, "8 chars, invalid length"},
+		{"123456789", false, "9 chars, invalid length"},
+
+		// 7-character valid commit hash (all valid hex characters)
+		{"abcdef0", true, "7-digit valid hash lowercase"},
+		{"ABCDEF0", true, "7-digit valid hash uppercase"},
+		{"a1B2c3D", true, "7-digit valid mix"},
+
+		// 7-character invalid commit hash (contains invalid character)
+		{"abcdeg0", false, "7-digit invalid hash, 'g' is not hex"},
+
+		// 40-character valid commit hash
+		{"0123456789abcdef0123456789abcdef01234567", true, "40-digit valid hash"},
+		// 40-character valid commit hash with uppercase letters
+		{"0123456789ABCDEF0123456789ABCDEF01234567", true, "40-digit valid hash uppercase"},
+
+		// 40-character invalid commit hash (contains an invalid character)
+		{"0123456789abcdef0123456789abcdef0123456g", false, "40-digit invalid hash, 'g' is not hex"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := IsCommitHash(tc.input)
+			if result != tc.expected {
+				t.Errorf("IsCommitHash(%q) = %v; want %v", tc.input, result, tc.expected)
+			}
+		})
+	}
+}
+
 // TestNormalizeVersion tests NormalizeVersion behavior.
 func TestNormalizeVersion(t *testing.T) {
 	cases := []struct {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -190,3 +190,32 @@ func ColorizeRow(row []string, c *color.Color) []string {
 	}
 	return colored
 }
+
+func CopyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		cerr := out.Close()
+		if err == nil {
+			err = cerr
+		}
+	}()
+
+	if _, err = io.Copy(out, in); err != nil {
+		return err
+	}
+
+	if err = os.Chmod(dst, 0755); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -295,14 +295,16 @@ func TestCopyFile_Success(t *testing.T) {
 		t.Errorf("copied content = %q; want %q", string(copied), string(content))
 	}
 
-	// Check the file permissions.
-	info, err := os.Stat(dstPath)
-	if err != nil {
-		t.Fatalf("Stat failed: %v", err)
-	}
-	// Only check the permission bits.
-	if info.Mode().Perm() != 0755 {
-		t.Errorf("permissions = %o; want %o", info.Mode().Perm(), 0755)
+	// On Unix systems, verify the file permissions.
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(dstPath)
+		if err != nil {
+			t.Fatalf("Stat failed: %v", err)
+		}
+		// Only check the permission bits.
+		if info.Mode().Perm() != 0755 {
+			t.Errorf("permissions = %o; want %o", info.Mode().Perm(), 0755)
+		}
 	}
 }
 

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -261,3 +261,55 @@ func TestColorizeRow(t *testing.T) {
 		}
 	}
 }
+
+func TestCopyFile_Success(t *testing.T) {
+	// Create a temporary directory for testing.
+	tempDir, err := os.MkdirTemp("", "copyfiletest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create a temporary source file.
+	srcPath := filepath.Join(tempDir, "src.txt")
+	content := []byte("Hello, world!")
+	if err := os.WriteFile(srcPath, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Define destination file path.
+	dstPath := filepath.Join(tempDir, "dst.txt")
+
+	// Call CopyFile.
+	if err := CopyFile(srcPath, dstPath); err != nil {
+		t.Fatalf("CopyFile failed: %v", err)
+	}
+
+	// Read the destination file to verify its contents.
+	copied, err := os.ReadFile(dstPath)
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+
+	if string(copied) != string(content) {
+		t.Errorf("copied content = %q; want %q", string(copied), string(content))
+	}
+
+	// Check the file permissions.
+	info, err := os.Stat(dstPath)
+	if err != nil {
+		t.Fatalf("Stat failed: %v", err)
+	}
+	// Only check the permission bits.
+	if info.Mode().Perm() != 0755 {
+		t.Errorf("permissions = %o; want %o", info.Mode().Perm(), 0755)
+	}
+}
+
+func TestCopyFile_SrcNotExist(t *testing.T) {
+	// Use a non-existent source file.
+	err := CopyFile("nonexistent.src", "shouldnotmatter.dst")
+	if err == nil {
+		t.Errorf("expected error when source file does not exist")
+	}
+}


### PR DESCRIPTION
This commit add support to build and use from any commit hash from
neovim repo as requested from #111 . The commit hash should be either in length 7 or 40. Note
that it adds dependencies to this project. The user will also need to
have `git`, `make` and `cmake` to build the project.
