### PR TITLE
fix(builder): add 1 retry attemp with clean directory if error happens

### DIFF
--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -10,16 +10,26 @@ import (
 	"testing"
 )
 
+// Global counter to simulate an error only on the first call.
+var simulateErrorCount int
+
 // fakeExecCommand is used to override execCommand in tests.
 func fakeExecCommand(ctx context.Context, command string, args ...string) *exec.Cmd {
-	// We use the standard helper process trick.
-	// The arguments passed to the helper process are:
-	//   -test.run=TestHelperProcess
-	//   "--", the command, then its args.
+	// If SIMULATE_RETRY is enabled and we haven't yet simulated an error, force an error.
+	if os.Getenv("SIMULATE_RETRY") == "1" && simulateErrorCount == 0 {
+		simulateErrorCount++
+		// Build the helper process command with SIMULATE_ERROR set.
+		cs := []string{"-test.run=TestHelperProcess", "--", command}
+		cs = append(cs, args...)
+		cmd := exec.Command(os.Args[0], cs...)
+		cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1", "SIMULATE_ERROR=1"}
+		return cmd
+	}
+
+	// Normal behavior: use the helper process simulation.
 	cs := []string{"-test.run=TestHelperProcess", "--", command}
 	cs = append(cs, args...)
 	cmd := exec.Command(os.Args[0], cs...)
-	// Set an env var so the helper process knows it’s supposed to run.
 	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
 	return cmd
 }
@@ -30,6 +40,12 @@ func TestHelperProcess(t *testing.T) {
 	// Only run if the special env var is present.
 	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
 		return
+	}
+
+	// Check if we are simulating an error.
+	if os.Getenv("SIMULATE_ERROR") == "1" {
+		fmt.Fprint(os.Stderr, "simulated error")
+		os.Exit(1)
 	}
 
 	// Parse arguments: look for "--" and then the command.
@@ -111,6 +127,10 @@ func TestHelperProcess(t *testing.T) {
 
 // TestBuildFromCommit_Master tests BuildFromCommit when commit is "master".
 func TestBuildFromCommit_Master(t *testing.T) {
+	// Reset simulateErrorCount to ensure no simulation.
+	simulateErrorCount = 0
+	os.Unsetenv("SIMULATE_RETRY")
+
 	// Override execCommand for testing.
 	oldExecCommand := execCommandFunc
 	execCommandFunc = fakeExecCommand
@@ -127,8 +147,6 @@ func TestBuildFromCommit_Master(t *testing.T) {
 	}
 	defer os.RemoveAll(versionsDir)
 
-	// For this test, we don't need to simulate a built binary in the localPath,
-	// because the cmake install simulation will create the installed binary.
 	// Call BuildFromCommit with commit "master".
 	if err := BuildFromCommit(context.Background(), "master", versionsDir); err != nil {
 		t.Fatalf("BuildFromCommit failed: %v", err)
@@ -155,6 +173,10 @@ func TestBuildFromCommit_Master(t *testing.T) {
 
 // TestBuildFromCommit_Commit tests BuildFromCommit for a non-master commit.
 func TestBuildFromCommit_Commit(t *testing.T) {
+	// Reset simulateErrorCount and ensure SIMULATE_RETRY is not set.
+	simulateErrorCount = 0
+	os.Unsetenv("SIMULATE_RETRY")
+
 	oldExecCommand := execCommandFunc
 	execCommandFunc = fakeExecCommand
 	defer func() { execCommandFunc = oldExecCommand }()
@@ -174,7 +196,7 @@ func TestBuildFromCommit_Commit(t *testing.T) {
 		t.Fatalf("BuildFromCommit failed: %v", err)
 	}
 
-	// The commit hash is always derived from the dummy "git rev-parse" output ("abcdef1"),
+	// The commit hash is derived from the dummy "git rev-parse" output ("abcdef1"),
 	// so the target directory should be versionsDir/abcdef1.
 	targetDir := filepath.Join(versionsDir, "abcdef1")
 	versionFile := filepath.Join(targetDir, "version.txt")
@@ -187,6 +209,53 @@ func TestBuildFromCommit_Commit(t *testing.T) {
 	}
 
 	// Verify that the installed binary exists.
+	installedBinary := filepath.Join(targetDir, "bin", "nvim")
+	if _, err := os.Stat(installedBinary); os.IsNotExist(err) {
+		t.Errorf("installed binary not found at %s", installedBinary)
+	}
+}
+
+// TestBuildFromCommit_Retry tests that BuildFromCommit will retry once on failure.
+func TestBuildFromCommit_Retry(t *testing.T) {
+	// Enable error simulation for the first call.
+	os.Setenv("SIMULATE_RETRY", "1")
+	// Reset the counter.
+	simulateErrorCount = 0
+
+	oldExecCommand := execCommandFunc
+	execCommandFunc = fakeExecCommand
+	defer func() {
+		execCommandFunc = oldExecCommand
+		os.Unsetenv("SIMULATE_RETRY")
+	}()
+
+	// Remove the local clone directory to force cloning.
+	localPath := filepath.Join(os.TempDir(), "neovim-src")
+	os.RemoveAll(localPath)
+
+	versionsDir, err := os.MkdirTemp("", "versions")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(versionsDir)
+
+	// Call BuildFromCommit; the first attempt will simulate an error,
+	// triggering the retry mechanism. On the second attempt, it should succeed.
+	if err := BuildFromCommit(context.Background(), "master", versionsDir); err != nil {
+		t.Fatalf("BuildFromCommit (with retry) failed: %v", err)
+	}
+
+	// Verify that the build ultimately succeeded.
+	targetDir := filepath.Join(versionsDir, "abcdef1")
+	versionFile := filepath.Join(targetDir, "version.txt")
+	data, err := os.ReadFile(versionFile)
+	if err != nil {
+		t.Fatalf("failed to read version file: %v", err)
+	}
+	if strings.TrimSpace(string(data)) != "abcdef1" {
+		t.Errorf("version file content = %q; want %q", string(data), "abcdef1")
+	}
+
 	installedBinary := filepath.Join(targetDir, "bin", "nvim")
 	if _, err := os.Stat(installedBinary); os.IsNotExist(err) {
 		t.Errorf("installed binary not found at %s", installedBinary)


### PR DESCRIPTION
Sometimes git command just go mad for whatever reason when i am using
it. Maybe it's better to just start from clean when it happens.
