### PR TITLE
chore(ci): bump golangci action to v8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
               with:
                   go-version: ${{ matrix.go }}
             - name: golangci-lint
-              uses: golangci/golangci-lint-action@v7
+              uses: golangci/golangci-lint-action@v8
               with:
-                  version: v2.0.2
+                  version: v2.1
     go-checks:
         name: ${{ matrix.check }}
         strategy:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the continuous integration workflow to use the latest version of the golangci-lint tool and its GitHub Action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->