### PR TITLE
fix(cmd.config): ensure getting the right standard path based on different OS

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -44,21 +44,17 @@ var configCmd = &cobra.Command{
 			return
 		}
 
-		// No configuration provided; list available Neovim configurations from ~/.config.
-		home, err := os.UserHomeDir()
+		configDir, err := utils.GetNvimConfigBaseDir()
 		if err != nil {
-			logrus.Fatalf("Failed to get home directory: %v", err)
+			logrus.Fatalf("Failed to determine config base dir: %v", err)
 		}
-		logrus.Debugf("User home directory: %s", home)
-
-		configDir := filepath.Join(home, ".config")
 		logrus.Debugf("Neovim config directory: %s", configDir)
 
 		entries, err := os.ReadDir(configDir)
 		if err != nil {
 			logrus.Fatalf("Failed to read config directory: %v", err)
 		}
-		logrus.Debugf("Found %d entries in config directory", len(entries))
+		logrus.Debugf("Found %d entries in config directory (%s)", len(entries), configDir)
 
 		var nvimConfigs []string
 		for _, entry := range entries {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -99,6 +99,60 @@ func GetCurrentVersion(versionsDir string) (string, error) {
 	return filepath.Base(target), nil
 }
 
+// GetStandardNvimConfigDir determines the canonical configuration directory
+// used by Neovim according to its runtime path conventions.
+//
+// Resolution order:
+//
+//  1. If the environment variable XDG_CONFIG_HOME is set, Neovim looks under
+//     $XDG_CONFIG_HOME/nvim. This is the highest-precedence override.
+//     Example (Linux/macOS):
+//     XDG_CONFIG_HOME="$HOME/.xdg"
+//     Example (Windows, PowerShell):
+//     $env:XDG_CONFIG_HOME="C:\xdg"
+//
+//  2. If XDG_CONFIG_HOME is not set, Neovim falls back to a platform-specific
+//     default:
+//
+//     • Linux/macOS → $HOME/.config
+//     Example: "/home/alice/.config"
+//     "/Users/alice/.config"
+//
+//     • Windows → %LOCALAPPDATA%
+//     Example: "C:\Users\alice\AppData\Local"
+//
+//  3. If LOCALAPPDATA is not set on Windows, this function falls back to
+//     $HOME/.config/nvim for consistency with other platforms.
+//
+// Returns:
+//   - The absolute path to the Neovim configuration directory.
+//   - An error if the user’s home directory cannot be determined when required.
+//
+// Notes:
+//   - This function does *not* consider tool-specific overrides such as
+//     NVS_CONFIG_DIR, because it is intended to strictly reflect Neovim’s
+//     own search path rules.
+//   - Callers should ensure that the returned directory exists before use;
+//     Neovim itself will create it lazily if needed.
+func GetNvimConfigBaseDir() (string, error) {
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		return filepath.Join(xdg), nil
+	}
+
+	if runtime.GOOS == "windows" {
+		if local := os.Getenv("LOCALAPPDATA"); local != "" {
+			return filepath.Join(local), nil
+		}
+		// fallback to home/.config if LOCALAPPDATA is missing
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".config"), nil
+}
+
 // FindNvimBinary walks through the given directory to find a Neovim binary.
 // On Windows it searches for "nvim.exe" (or prefixed names with .exe),
 // while on other OSes it looks for "nvim" (or prefixed names) that are executable.


### PR DESCRIPTION
Fix #135 